### PR TITLE
Leaflet.js total refactor!

### DIFF
--- a/src/providers/tile/Leaflet.js
+++ b/src/providers/tile/Leaflet.js
@@ -52,6 +52,7 @@ class Leaflet extends TileMap {
           ctx = canvas.getContext('webgl') || canvas.getContext('2d');
 
     if (this.tiles)  this.tiles.options.opacity = this.options.opacity;
+
     this.map.addLayer(L.overlay());
 
     this.map.on('move', () => {

--- a/src/providers/tile/Leaflet.js
+++ b/src/providers/tile/Leaflet.js
@@ -72,7 +72,8 @@ class Leaflet extends TileMap {
 
   fromPointToLatLng(...args) {
     if (this.ready) {
-      return this.map.containerPointToLatLng(args);
+      const { lat, lng } = this.map.containerPointToLatLng(args);
+      return { lat, lng };
     }
     return { lat: -100, lng: -100 };
   }

--- a/src/providers/tile/Leaflet.js
+++ b/src/providers/tile/Leaflet.js
@@ -13,7 +13,7 @@ class Leaflet extends TileMap {
     this.styleSrc = 'https://unpkg.com/leaflet@1.3/dist/leaflet.css';
     this.ready = false;
 
-    this.constructor.name === 'Leaflet' && this.loadSrc();
+    if (this.constructor.name === 'Leaflet')  this.loadSrc();
   }
 
   createMap() {
@@ -43,20 +43,20 @@ class Leaflet extends TileMap {
         map.off();
         delete this._container;
       },
-      drawLayer() { }
+      drawLayer() {}
     });
 
     L.overlay = () => new L.Layer.Overlay;
 
-    this.tiles && (this.tiles.options.opacity = this.options.opacity);
-    this.map.addLayer(L.overlay());
-
     const { canvas } = this,
           ctx = canvas.getContext('webgl') || canvas.getContext('2d');
 
+    if (this.tiles)  this.tiles.options.opacity = this.options.opacity;
+    this.map.addLayer(L.overlay());
+
     this.map.on('move', () => {
       const d = this.map.dragging._draggable._newPos;
-      d && (ctx.canvas.style.transform = `translate(${-d.x}px, ${-d.y}px)`);
+      if (d)  ctx.canvas.style.transform = `translate(${-d.x}px, ${-d.y}px)`;
     });
 
     return this;

--- a/src/providers/tile/Leaflet.js
+++ b/src/providers/tile/Leaflet.js
@@ -58,7 +58,7 @@ class Leaflet extends TileMap {
 
     this.map.on('move', () => {
       const d = this.map.dragging._draggable._newPos;
-      d && ctx.canvas.style.transform = `translate(${-d.x}px, ${-d.y}px)`;
+      d && (ctx.canvas.style.transform = `translate(${-d.x}px, ${-d.y}px)`);
     });
 
     return this;

--- a/src/providers/tile/Leaflet.js
+++ b/src/providers/tile/Leaflet.js
@@ -1,5 +1,5 @@
 // -----------
-// Leaflet v1.3.1
+// Leaflet v1.3.1 (1.3.x)
 // Reference: http://LeafletJS.com/reference-1.3.0.html
 //-----------
 

--- a/src/providers/tile/Leaflet.js
+++ b/src/providers/tile/Leaflet.js
@@ -78,7 +78,8 @@ class Leaflet extends TileMap {
   }
 
   getZoom() {
-    return this.ready? this.map.getZoom() : 0;
+    if (this.ready)  return this.map.getZoom();
+    return 0;
   }
 
   onChange(callback) {

--- a/src/providers/tile/Leaflet.js
+++ b/src/providers/tile/Leaflet.js
@@ -48,11 +48,13 @@ class Leaflet extends TileMap {
           if (d) ctx.canvas.style.transform = `translate(${-d.x}px, ${-d.y}px)`;
         });
       },
+
       onRemove(map) {
         L.DomUtil.remove(this._container);
         map.off();
         delete this._container;
       },
+
       drawLayer() {}
     });
 

--- a/src/providers/tile/Leaflet.js
+++ b/src/providers/tile/Leaflet.js
@@ -8,6 +8,7 @@ import TileMap from './TileMap';
 class Leaflet extends TileMap {
   constructor(options) {
     super(options);
+    this.map = this.tiles = null;
 
     this.scriptSrc = 'https://unpkg.com/leaflet@1.3/dist/leaflet.js';
     this.styleSrc = 'https://unpkg.com/leaflet@1.3/dist/leaflet.css';

--- a/src/providers/tile/Leaflet.js
+++ b/src/providers/tile/Leaflet.js
@@ -32,11 +32,21 @@ class Leaflet extends TileMap {
   }
 
   canvasOverlay() {
+    const { canvas } = this,
+          ctx = canvas.getContext('webgl') || canvas.getContext('2d');
+
+    if (this.tiles) this.tiles.options.opacity = this.options.opacity;
+
     L.Layer.Overlay = L.Layer.extend({
       onAdd(map) {
         this._container = L.DomUtil.create('div', 'leaflet-layer');
         this._container.appendChild(canvas);
         map.getPane(this.options.pane).appendChild(this._container);
+
+        map.on('move', () => {
+          const d = map.dragging._draggable._newPos;
+          if (d) ctx.canvas.style.transform = `translate(${-d.x}px, ${-d.y}px)`;
+        });
       },
       onRemove(map) {
         L.DomUtil.remove(this._container);
@@ -47,18 +57,7 @@ class Leaflet extends TileMap {
     });
 
     L.overlay = () => new L.Layer.Overlay;
-
-    const { canvas } = this,
-          ctx = canvas.getContext('webgl') || canvas.getContext('2d');
-
-    if (this.tiles)  this.tiles.options.opacity = this.options.opacity;
-
     this.map.addLayer(L.overlay());
-
-    this.map.on('move', () => {
-      const d = this.map.dragging._draggable._newPos;
-      if (d)  ctx.canvas.style.transform = `translate(${-d.x}px, ${-d.y}px)`;
-    });
 
     return this;
   }

--- a/src/providers/tile/Leaflet.js
+++ b/src/providers/tile/Leaflet.js
@@ -1,6 +1,6 @@
 // -----------
-// Leaflet v1.3.0
-// Reference: http://leafletjs.com/reference-1.3.0.html
+// Leaflet v1.3.1
+// Reference: http://LeafletJS.com/reference-1.3.0.html
 //-----------
 
 import TileMap from './TileMap';
@@ -8,90 +8,79 @@ import TileMap from './TileMap';
 class Leaflet extends TileMap {
   constructor(options) {
     super(options);
-    this.scriptSrc = 'https://unpkg.com/leaflet@1.3.0/dist/leaflet.js';
-    this.styleSrc = 'https://unpkg.com/leaflet@1.3.0/dist/leaflet.css';
+
+    this.scriptSrc = 'https://unpkg.com/leaflet@1.3/dist/leaflet.js';
+    this.styleSrc = 'https://unpkg.com/leaflet@1.3/dist/leaflet.css';
     this.ready = false;
-    if (this.constructor.name === 'Leaflet') {
-      this.loadSrc();
-    }
+
+    this.constructor.name === 'Leaflet' && this.loadSrc();
   }
 
   createMap() {
-    this.map = L.map(this.id, {
-      center: [
-        this.options.lat, this.options.lng,
-      ],
-      zoom: this.options.zoom,
-      inertia: false,
-    });
+    const { lat, lng, zoom, style } = this.options;
+    this.map = L.map(this.id, { center: [ lat, lng ], zoom, inertia: false });
 
-    if (!this.options.style) {
+    if (!style) {
       Leaflet.messages().tiles();
       this.ready = true;
     } else {
-      this.tiles = L.tileLayer(this.options.style).addTo(this.map);
-      this.tiles.on('tileload', () => {
-        this.ready = true;
-      });
+      this.tiles = L.tileLayer(style).addTo(this.map);
+      this.tiles.on('tileload', () => this.ready = true);
     }
-    this.canvasOverlay();
+
+    return this.canvasOverlay();
   }
 
   canvasOverlay() {
-    if (this.tiles) {
-      this.tiles.options.opacity = this.options.opacity;
-    }
-    L.overlay = L.Layer.extend({
-      onAdd: () => {
-        const overlayPane = overlay.getPane();
-        const container = L.DomUtil.create('div', 'leaflet-layer');
-        container.appendChild(this.canvas);
-        overlayPane.appendChild(container);
+    L.Layer.Overlay = L.Layer.extend({
+      onAdd(map) {
+        this._container = L.DomUtil.create('div', 'leaflet-layer');
+        this._container.appendChild(canvas);
+        map.getPane(this.options.pane).appendChild(this._container);
       },
-      drawLayer: () => {},
+      onRemove(map) {
+        L.DomUtil.remove(this._container);
+        map.off();
+        delete this._container;
+      },
+      drawLayer() { }
     });
-    const overlay = new L.overlay();
-    this.map.addLayer(overlay);
-    
 
-    const cnvs = this.canvas.getContext('webgl') || this.canvas.getContext('2d');
+    L.overlay = function () {
+      return new L.Layer.Overlay;
+    };
+
+    this.tiles && (this.tiles.options.opacity = this.options.opacity);
+    this.map.addLayer(L.overlay());
+
+    const { canvas } = this,
+          ctx = canvas.getContext('webgl') || canvas.getContext('2d');
+
     this.map.on('move', () => {
-      const d = this.map.dragging._draggable;
-      if (d._newPos) {
-        cnvs.canvas.style.transform = `translate(${-d._newPos.x}px, ${-d._newPos.y}px)`;
-      };
-    })
+      const d = this.map.dragging._draggable._newPos;
+      d && ctx.canvas.style.transform = `translate(${-d.x}px, ${-d.y}px)`;
+    });
+
+    return this;
   }
 
   fromLatLngToPixel(position) {
     if (this.ready) {
-      const containerPoint = this.map.latLngToContainerPoint(position);
-      return {
-        x: containerPoint.x,
-        y: containerPoint.y,
-      };
+      const { x, y } = this.map.latLngToContainerPoint(position);
+      return { x, y };
     }
-    return {
-      x: -100,
-      y: -100, 
-    };
+    return { x: -100, y: -100 };
   }
 
   fromPointToLatLng(...args) {
     if (this.ready) {
       return this.map.containerPointToLatLng(args);
     }
-    return {
-      lat: -100,
-      lng: -100,
-    };
+    return { lat: -100, lng: -100 };
   }
 
   getZoom() {
-    if (this.ready) {
-      return this.map.getZoom();
-    }
-    return 0;
+    return this.ready? this.map.getZoom() : 0;
   }
 
   onChange(callback) {
@@ -99,22 +88,24 @@ class Leaflet extends TileMap {
       callback();
       this.map.on('move', callback);
     } else {
-      setTimeout(() => {
-        this.onChange(callback);
-      }, 200);
+      setTimeout(() => this.onChange(callback), 200);
     }
+    return this;
   }
 
   removeOnChange(callback) {
     this.map.on('move', callback);
+    return this;
   }
 
   static messages() {
     return {
-      tiles: () => {
-        console.warn('You are not using any tiles for your map. Try with: http://{s}.tile.osm.org/{z}/' +
-          '{x}/{y}.png');
-      },
+      tiles() {
+        console.warn(
+          'You are not using any tiles for your map.',
+          'Try out with: http://{s}.tile.osm.org/{z}/' + '{x}/{y}.png'
+        );
+      }
     };
   }
 }

--- a/src/providers/tile/Leaflet.js
+++ b/src/providers/tile/Leaflet.js
@@ -46,9 +46,7 @@ class Leaflet extends TileMap {
       drawLayer() { }
     });
 
-    L.overlay = function () {
-      return new L.Layer.Overlay;
-    };
+    L.overlay = () => new L.Layer.Overlay;
 
     this.tiles && (this.tiles.options.opacity = this.options.opacity);
     this.map.addLayer(L.overlay());


### PR DESCRIPTION
After taking a hard look at Leaflet.js (also TileMap.js) in order to find a more proper solution for some1 from the Processing's forum:
https://Forum.Processing.org/two/discussion/26239/p5-js-mappa-js-unable-to-place-map-in-parent-div#Item_4

I've found out this class _**Leaflet**_ got some tiny minor cosmetic issues. And that I could refactor it.  :P  

1) Current latest Leaflet.JS' version is now 1.3.1. But this class is loading 1.3.0 instead.
So I've changed 'https://unpkg.com/leaflet@1.3.0/dist/leaflet.js' to 'https://unpkg.com/leaflet@1.3/dist/leaflet.js'.
`@1.3`, rather than `@1.3.0`, will automatically pick latest version from range v1.3.0 to v1.3.9.
I don't think patch updates are that dangerous, are they?

2) In **canvasOverlay()**, you've got an custom subclass from _**L.Layer**_ named as _**L.overlay**_.
However, according to JS/Java's conventions, class names should be capitalized.
Therefore I've renamed _**L.overlay**_ to _**L.Layer.Overlay**_.
Then made a custom **L.overlay()** function which instantiates that just renamed subclass.  ^_^
Given the now wrapper function got the same name as the previous subclass' name, no API call had been changed!

3) Besides that renaming and a new wrapper function in its place, I've found some instructions about extending class _**L.Layer**_ below:
http://LeafletJS.com/examples/extending/extending-2-layers.html
However, your approach differs greatly from the article above.
You use an arrow function for _**L.Layer**_::**onAdd()** method, permanently sealing its `this` to that of subclass _**Leaflet**_'s.
You do that in order to access _this.canvas_ inside _**L.Layer**_::**onAdd()**, I know.
Well, I've refactored it to access _this.canvas_ as a closure variable simply called _canvas_ there.

Well, those are my main changes. There are many more tiny 1s throughout the file though.  :D  
Got no idea how much you're gonna like them. Just tell me which 1s to revert back then.

P.S.: Not tested at all!!!