### PR TITLE
glitch in threejs example fixed

### DIFF
--- a/examples/tile/Threejs/script.js
+++ b/examples/tile/Threejs/script.js
@@ -66,7 +66,7 @@ var options = {
     //style: 'http://{s}.tile.osm.org/{z}/{x}/{y}.png'
 }
 
-var mappa = new Mappa('Mapboxgl', key);
+var mappa = new Mappa('MapboxGL', key);
 var myMap = mappa.tileMap(options);
 myMap.overlay(canvas);
 myMap.onChange(update);


### PR DESCRIPTION
keep facing this error. 
Uncaught TypeError: _tileMap[this.provider] is not a constructor
    at Mappa.tileMap (mappa.js:647)
    at script.js:71

to avoid this i changed bit in 'examples/tile/Threejs/script.js'

from
**var mappa = new Mappa('Mapboxgl', key);**
to
**var mappa = new Mappa('MapboxGL', key);**